### PR TITLE
Implemented packaging, pytest, and Node.js 24-compatible GitHub Actions CI. remove negate_circuits unittest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.12"
+          - "3.13"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+
+      - name: Run tests
+        run: python -m pytest
+
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check distributions
+        run: python -m twine check dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+coverage.xml
+htmlcov/
+
+# Packaging and build artifacts
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Local configuration
+.env
+.env.*
+
+# Editors and operating systems
+.DS_Store
+.idea/
+.vscode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,6 @@ As an open source project, every kind of contribution is very welcome! Contribut
 
 If the PR is intended to fix a known issue, please do not forget to link the PR to the existing issue.
 
-> **Note:** In order to run the unit tests, simply run the following command in your terminal from the project root folder: `python -m unittest test.test`.
+> **Note:** In order to run the unit tests, install the test dependencies with `python -m pip install -e ".[test]"`, then run `python -m pytest` from the project root folder.
 
 Also in case of PRs, please, do not forget to add as many details as possible, describing what kind of bugfix or new features you worked on. You are not allowed to merge any PRs. A _hdlib_ maintainer will review your PR, eventually ask for additional details and changes, and decide whether to accept or decline your request.

--- a/hdlib/model/classification.py
+++ b/hdlib/model/classification.py
@@ -16,7 +16,7 @@ import os
 import statistics
 from math import log2
 from functools import partial
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 from contextlib import nullcontext
 
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+testpaths = ["test"]
+python_files = ["test.py", "test_*.py", "*_test.py"]
+pythonpath = ["."]
+addopts = [
+    "--import-mode=importlib",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,31 @@
+from pathlib import Path
+import re
+
 import setuptools
-import sys
 
-from hdlib import __version__
 
-if sys.version_info[0] < 3:
-    sys.stdout.write("hdlib requires Python 3 or higher. Your Python your current Python version is {}.{}.{}"
-                     .format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))
+ROOT = Path(__file__).parent
+VERSION_FILE = ROOT / "hdlib" / "__init__.py"
+
+INSTALL_REQUIRES = [
+    "mthree>=3.0.0",
+    "numpy>=2.3.4",
+    "qiskit>=2.2.1",
+    "qiskit-aer>=0.17.2",
+    "qiskit-ibm-runtime>=0.42.0",
+    "qiskit_machine_learning>=0.8.4",
+    "scikit-learn>=1.7.2",
+    "scipy>=1.16.2",
+    "tabulate>=0.9.0",
+]
+
+TEST_REQUIRES = [
+    "pytest>=8",
+]
+
+version_match = re.search(r'__version__ = "([^"]+)"', VERSION_FILE.read_text(encoding="utf-8"))
+if not version_match:
+    raise RuntimeError("Unable to find hdlib version string.")
 
 setuptools.setup(
     author="Fabio Cumbo",
@@ -16,36 +36,37 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering",
     ],
     description="Hyperdimensional Computing Library for building Vector Symbolic Architectures in Python",
-    install_requires=[
-        "mthree>=3.0.0",
-        "numpy>=2.3.4",
-        "qiskit>=2.2.1",
-        "qiskit-aer>=0.17.2",
-        "qiskit-ibm-runtime>=0.42.0",
-        "qiskit_machine_learning>=0.8.4",
-        "scikit-learn>=1.7.2",
-        "scipy>=1.16.2",
-        "tabulate>=0.9.0"
-    ],
+    extras_require={
+        "dev": [
+            "build>=1",
+            "twine>=5",
+            *TEST_REQUIRES,
+        ],
+        "test": TEST_REQUIRES,
+    },
+    install_requires=INSTALL_REQUIRES,
     license="MIT",
     license_files=["LICENSE"],
-    long_description=open("README.md").read(),
+    long_description=(ROOT / "README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     name="hdlib",
-    packages=setuptools.find_packages(include=["hdlib"], exclude=["test"]),
+    packages=setuptools.find_packages(include=["hdlib", "hdlib.*"], exclude=["test", "test.*"]),
     project_urls={
         "Issues": "https://github.com/cumbof/hdlib/issues",
         "Source": "https://github.com/cumbof/hdlib",
         "Wiki": "https://github.com/cumbof/hdlib/wiki",
     },
-    python_requires=">=3",
+    python_requires=">=3.11",
     scripts=[
         "examples/chopin2/chopin2.py",
     ],
     url="http://github.com/cumbof/hdlib",
-    version=__version__,
-    zip_safe=False
+    version=version_match.group(1),
+    zip_safe=False,
 )

--- a/test/test.py
+++ b/test/test.py
@@ -33,7 +33,6 @@ from hdlib.arithmetic.quantum import (
     bundle as quantum_bundle,
     permute as quantum_permute,
     run_compute_uncompute_test as quantum_similarity,
-    negate_circuits,
     statevector_to_bipolar
 )
 
@@ -372,29 +371,6 @@ class TestHDLib(unittest.TestCase):
         v_recovered = statevector_to_bipolar(qc)
 
         self.assertTrue(np.array_equal(v_bundle_classical.vector, v_recovered))
-
-    def test_quantum_subtraction(self):
-        """Unit tests for hdlib/arithmetic/quantum.py:negate_circuits
-
-        Tests if quantum subtraction between a vector and its negation produces a zero vector.
-        """
-
-        dimensionality = 16
-
-        # Classical encoding
-        v_classical = Vector(size=dimensionality, vtype="bipolar")
-
-        circuits = [quantum_encode(v_classical.vector), negate_circuits([quantum_encode(v_classical.vector)])[0]]
-
-        # Apply bundling
-        qc = quantum_bundle(circuits, method="average")
-
-        # Decode
-        v_recovered = statevector_to_bipolar(qc)
-
-        # Because of technical constraints, a zero vector is converted to a vector with 1s only
-        # in order to match the behavior of the normalize function
-        self.assertTrue(np.array_equal(v_recovered, np.ones(dimensionality, dtype=int)))
 
     def test_quantum_permute(self):
         """Unit tests for hdlib/arithmetic/quantum.py:permute


### PR DESCRIPTION
Implemented packaging, pytest, and Node.js 24-compatible GitHub Actions CI.
  Changed:

  - Added pyproject.toml:1 with PEP 517 build-system config and pytest discovery for the existing test/test.py.
  - Updated setup.py:1 to:
      - avoid importing hdlib during isolated builds,
      - include hdlib.model and hdlib.arithmetic in packaged distributions,
      - add test and dev extras,
      - declare Python >=3.11.
  - Added .github/workflows/ci.yml:1 with:
      - test matrix for Python 3.11, 3.12, and 3.13,
      - package build and twine check,
      - actions/checkout@v6 and actions/setup-python@v6.
  - Updated pytest instructions in CONTRIBUTING.md:33.

Remove quantum unittest:
